### PR TITLE
Revert "Bump Microsoft.CodeAnalysis.Common from 3.8.0 to 3.9.0"

### DIFF
--- a/Origam.ServerCore/Origam.ServerCore.csproj
+++ b/Origam.ServerCore/Origam.ServerCore.csproj
@@ -67,7 +67,7 @@
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.Abstractions" Version="5.0.6" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="5.0.6" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="5.0.6" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="3.9.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="3.8.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Log4Net.AspNetCore" Version="5.0.1" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="5.0.2" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />


### PR DESCRIPTION
Reverts origam/origam-source#102 because of problems with FastReport