### PR TITLE
Fix #755 - International characters in FastReports

### DIFF
--- a/OrigamDocker/Dockerfile
+++ b/OrigamDocker/Dockerfile
@@ -18,6 +18,22 @@ RUN chmod +x updateTimezone.sh
 RUN su origam
 USER origam
 WORKDIR /home/origam
+
+# Fix of https://community.origam.com/t/not-displaying-c-at-the-end-of-words-in-pdf-generated-from-fastreport/755/19
+# Rebuilding libgdiplus library to correctly display international characters 
+# in FastReports. i.e. in czech language it doesn't display è located in the end
+# of string. Instead of Kè it printed just K.
+
+RUN sudo apt-get -y install libgif-dev autoconf libtool automake build-essential gettext libglib2.0-dev libcairo2-dev libtiff-dev libexif-dev libpango1.0-dev
+RUN git clone https://github.com/mono/libgdiplus.git /home/origam/libgdiplus
+WORKDIR /home/origam/libgdiplus
+RUN ./autogen.sh --with-pango --prefix=/usr
+RUN make
+RUN sudo make install
+
+#End of rebuild libgdiplus
+
+WORKDIR /home/origam
 RUN mkdir HTML5
 COPY --chown=origam:origam HTML5 /home/origam/HTML5
 COPY --chown=origam:origam ["_appsettings.template", "/home/origam/HTML5"]
@@ -27,7 +43,7 @@ COPY --chown=origam:origam ["startServer.sh", "/home/origam/HTML5"]
 COPY --chown=origam:origam ["log4net.config", "/home/origam/HTML5"]
 COPY --chown=origam:origam ["updateEnvironment.sh", "/home/origam/HTML5"]
 COPY --chown=origam:origam ["updateEnvironmentRoot.sh", "/home/origam/HTML5"]
-WORKDIR HTML5
+WORKDIR /home/origam/HTML5
 RUN mkdir data
 RUN mkdir logs
 RUN chmod +x startServer.sh


### PR DESCRIPTION
Fix https://community.origam.com/t/not-displaying-c-at-the-end-of-words-in-pdf-generated-from-fastreport/755

* Dockerfile build now contains rebuilding libgdiplus library to correctly display international characters inside FastReports reports.