### PR TITLE
FIX: Removed calendar filter by date so AS:AddWorkingDays would work …

### DIFF
--- a/Origam.Rule/RuleEngine.cs
+++ b/Origam.Rule/RuleEngine.cs
@@ -1370,7 +1370,6 @@ namespace Origam.Rule
 				new Guid("8225b839-f336-4171-b05d-7b9aa5d39afc"));
 
 			q.Parameters.Add(new QueryParameter("OrigamCalendar_parId", calendarGuid));
-			q.Parameters.Add(new QueryParameter("OrigamCalendarDetail_parDate", result));
 
 			DataSet ds = LoadData(q);
 			CalendarDataset calendar = new CalendarDataset();


### PR DESCRIPTION
…properly when using negative shift.

e.g. getting the first working day before 7 days ago by using AS:AddWorkingDays($today, -7, $calendarId).
Requires a Root model update.