### PR TITLE
Mailing subsystem fixes

### DIFF
--- a/Origam.Mail/MailLogUtils.cs
+++ b/Origam.Mail/MailLogUtils.cs
@@ -54,7 +54,10 @@ namespace Origam.Mail
             builder.Append($"\tDeliveryFormat: {client.DeliveryFormat}\n");
             builder.Append($"\tDeliveryMethod: {client.DeliveryMethod}\n");
             builder.Append($"\tEnableSsl: {client.EnableSsl}\n");
-            builder.Append($"\tServicePoint.Address: {client.ServicePoint.Address}\n");
+            if (!string.IsNullOrEmpty(client.Host))
+            {
+                builder.Append($"\tServicePoint.Address: {client.ServicePoint.Address}\n");
+            }
             builder.Append($"\tTargetName: {client.TargetName}\n");
             builder.Append($"\tPickupDirectoryLocation: {client.PickupDirectoryLocation}\n");
             builder.Append($"\tUseDefaultCredentials: {client.UseDefaultCredentials}\n");

--- a/Origam.Mail/NetStandardMailService.cs
+++ b/Origam.Mail/NetStandardMailService.cs
@@ -49,7 +49,7 @@ namespace Origam.Mail
             string server, int port, string pickupDirectoryLocation,
             string username = null, string password = null, bool useSsl = true)
         {
-            if( !string.IsNullOrWhiteSpace(pickupDirectoryLocation)
+            if(!string.IsNullOrWhiteSpace(pickupDirectoryLocation)
             && !string.IsNullOrWhiteSpace(server))
             {
                 throw new ArgumentException(
@@ -163,7 +163,7 @@ namespace Origam.Mail
                     string toName = "";
                     string toAddress = "";
                     OpenPOP.MIMEParser.Utility.ParseEmailAddress(recipient, ref toName, ref toAddress);
-                    if (string.IsNullOrEmpty(recipient))
+                    if (!string.IsNullOrEmpty(recipient))
                     {
                         m.To.Add(new MailAddress(toAddress, toName));
                     }
@@ -241,7 +241,7 @@ namespace Origam.Mail
         private SmtpClient BuildSmtpClient(string server, int port)
         {
             var smtpClient = new SmtpClient();
-            if (server != null)
+            if (!string.IsNullOrEmpty(server))
             {
                 smtpClient.Host = server;
                 smtpClient.Port = port;


### PR DESCRIPTION
- SendMail2 didn't attach any recepients
- BuildSmtpServer didn't detect empty string as server not being defined
- if MailLogUtils were enabled and pickup directory was specified, logging failed and mail wasn't sent out