### PR TITLE
Workflow exceptions were treated as unhandled and terminated the server instance

### DIFF
--- a/Origam.Workflow/Tasks/AbstractWorkflowEngineTask.cs
+++ b/Origam.Workflow/Tasks/AbstractWorkflowEngineTask.cs
@@ -45,7 +45,7 @@ namespace Origam.Workflow.Tasks
 		public event WorkflowEngineTaskFinished Finished;
 		protected virtual void OnFinished(WorkflowEngineTaskEventArgs e)
 		{
-            if (e.Exception != null)
+			if (this.Step == null)
             {
                 throw e.Exception;
             }


### PR DESCRIPTION
Unintended impact of the #286. If workflow step ended up with an exception, the exception was throw in unhandled context and server instance was terminated.