### PR TITLE
FIX: If the value "false" was given to a boolean parameter in a xslt …

### DIFF
--- a/Origam.Rule/MicrosoftXsltEngine.cs
+++ b/Origam.Rule/MicrosoftXsltEngine.cs
@@ -124,6 +124,10 @@ namespace Origam.Rule
                             XPathNodeIterator iterator = nav.Select("/");
                             val = iterator;
                         }
+                        else if (param.Value is bool)
+                        {
+                            val = param.Value;
+                        }
                         else
                         {
                             val = XmlTools.ConvertToString(param.Value);


### PR DESCRIPTION
…transformation it was interpreted as "true"

because the value was internally converted to string